### PR TITLE
Fix nil player error in medical state handler

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -30,11 +30,13 @@ RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()
 end)
 
 AddStateBagChangeHandler(DEATH_STATE_STATE_BAG, nil, function(bagName, _, value)
-	local playerId = GetPlayerFromStateBagName(bagName)
-	local player = exports.qbx_core:GetPlayer(playerId)
-	player.Functions.SetMetaData('isdead', value == sharedConfig.deathState.DEAD)
-	player.Functions.SetMetaData('inlaststand', value == sharedConfig.deathState.LAST_STAND)
-	Player(playerId).state:set("isDead", value == sharedConfig.deathState.DEAD or value == sharedConfig.deathState.LAST_STAND, true)
+    local playerId = GetPlayerFromStateBagName(bagName)
+    local player = playerId and exports.qbx_core:GetPlayer(playerId)
+    if not player then return end
+
+    player.Functions.SetMetaData('isdead', value == sharedConfig.deathState.DEAD)
+    player.Functions.SetMetaData('inlaststand', value == sharedConfig.deathState.LAST_STAND)
+    Player(playerId).state:set('isDead', value == sharedConfig.deathState.DEAD or value == sharedConfig.deathState.LAST_STAND, true)
 end)
 
 ---@param player table|number


### PR DESCRIPTION
## Summary
- avoid nil indexing in server death state handler

## Testing
- `npx eslint`


------
https://chatgpt.com/codex/tasks/task_e_6841c8a9ea948320b87d6a562988aaef